### PR TITLE
Update Qiskit Aer benchmarks for Qiskit Aer 0.4

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -31,7 +31,7 @@ install() {
     source activate ./env
     echo "installing Python dependencies"
     conda install -p env -y numpy matplotlib mkl-service pytest pybind11 pytest-benchmark ipython
-    ./env/bin/pip install qiskit cirq projectq pyquest-cffi pennylane qulacs-gpu
+    ./env/bin/pip install qiskit qiskit-aer-gpu cirq projectq pyquest-cffi pennylane qulacs-gpu
 
     # install Julia dependencies
     echo "installing Julia dependencies"

--- a/bin/plot
+++ b/bin/plot
@@ -10,7 +10,7 @@ gate_data = parse_data(
 )
 
 circuit_data = parse_data(
-    packages=['projectq', 'cirq', 'quest', 'pennylane', 'qulacs', 'yao'],
+    packages=['projectq', 'qiskit', 'cirq', 'quest', 'pennylane', 'qulacs', 'yao'],
     labels=['QCBM']
 )
 

--- a/bin/utils/plot_utils.py
+++ b/bin/utils/plot_utils.py
@@ -11,6 +11,7 @@ COLOR = {
     'yao x 1000': 'tab:blue',
     'yao x 64': 'tab:blue',
     'qiskit': 'tab:green',
+    'qiskit (cuda)': 'tab:gray',
     'projectq': 'tab:blue',
     'cirq': 'tab:cyan',
     'quest': 'tab:olive',
@@ -76,6 +77,12 @@ def parse_data(packages, labels=['X', 'H', 'T', 'CNOT', 'Toffoli']):
             if len(labels) == 1 and 'QCBM' in labels:
                 gate_data['qulacs'] = wash_benchmark_data(each_package, ['QCBM'])
                 gate_data['qulacs (cuda)'] = wash_benchmark_data(each_package, ['QCBM (cuda)']).rename(columns={'QCBM (cuda)': 'QCBM'})
+            else:
+                gate_data[each_package] = wash_benchmark_data(each_package, labels)
+        elif each_package == 'qiskit':
+            if len(labels) == 1 and 'QCBM' in labels:
+                gate_data['qiskit'] = wash_benchmark_data(each_package, ['QCBM'])
+                gate_data['qiskit (cuda)'] = wash_benchmark_data(each_package, ['QCBM (cuda)']).rename(columns={'QCBM (cuda)': 'QCBM'})
             else:
                 gate_data[each_package] = wash_benchmark_data(each_package, labels)
         else:

--- a/qiskit/benchmarks.py
+++ b/qiskit/benchmarks.py
@@ -15,13 +15,13 @@ default_options = {
 def _execute(circuit, backend_options=None):
     experiment = transpile(circuit, backend)
     qobj = assemble(experiment, shots=1)
-    qobj_aer = backend._format_qobj_str(qobj, backend_options, None)
+    qobj_aer = backend._format_qobj(qobj, backend_options, None)
     return backend._controller(qobj_aer)
 
 def native_execute(benchmark, circuit, backend_options=None):
     experiment = transpile(circuit, backend)
     qobj = assemble(experiment, shots=1)
-    qobj_aer = backend._format_qobj_str(qobj, backend_options, None)
+    qobj_aer = backend._format_qobj(qobj, backend_options, None)
     benchmark(backend._controller, qobj_aer)
 
 def run_bench(benchmark, nqubits, gate, locs=(1, )):

--- a/qiskit/benchmarks.py
+++ b/qiskit/benchmarks.py
@@ -1,101 +1,96 @@
 import pytest
 import mkl
 import uuid
-from qiskit import *
+from qiskit import Aer, QuantumCircuit
 from qiskit.compiler import transpile, assemble
 mkl.set_num_threads(1)
 
-backend = Aer.get_backend('statevector_simulator')
+backend = Aer.get_backend("qasm_simulator")
+default_options = {
+    "method": "statevector",   # Force dense statevector method for benchmarks
+    "truncate_enable": False,  # Disable unused qubit truncation for benchmarks
+    "max_parallel_threads": 1  # Disable OpenMP parallelization for benchmarks
+}
 
-def _execute(circuit):
-    experiment = transpile(circuit)
-    qobj = assemble(experiment)
-    qobj_str = backend._format_qobj_str(qobj, None, None)
-    return backend._controller(qobj_str)
+def _execute(circuit, backend_options=None):
+    experiment = transpile(circuit, backend)
+    qobj = assemble(experiment, shots=1)
+    qobj_aer = backend._format_qobj_str(qobj, backend_options, None)
+    return backend._controller(qobj_aer)
 
-def native_execute(benchmark, circuit):
-    experiment = transpile(circuit)
-    qobj = assemble(experiment)
-    qobj_str = backend._format_qobj_str(qobj, None, None)
-    benchmark(backend._controller, qobj_str)
+def native_execute(benchmark, circuit, backend_options=None):
+    experiment = transpile(circuit, backend)
+    qobj = assemble(experiment, shots=1)
+    qobj_aer = backend._format_qobj_str(qobj, backend_options, None)
+    benchmark(backend._controller, qobj_aer)
 
 def run_bench(benchmark, nqubits, gate, locs=(1, )):
-    q = QuantumRegister(nqubits)
-    qc = QuantumCircuit(q)
+    qc = QuantumCircuit(nqubits)
     getattr(qc, gate)(*locs)
-    native_execute(benchmark, qc)
+    native_execute(benchmark, qc, default_options)
 
-def first_rotation(circuit, qubits):
-    for each in qubits:
-        circuit.rx(1.0, each)
-        circuit.rz(1.0, each)
+def first_rotation(circuit, nqubits):
+    circuit.rx(1.0, range(nqubits))
+    circuit.rz(1.0, range(nqubits))
     return circuit
 
-def mid_rotation(circuit, qubits):
-    for each in qubits:
-        circuit.rz(1.0, each)
-        circuit.rx(1.0, each)
-        circuit.rz(1.0, each)
+def mid_rotation(circuit, nqubits):
+    circuit.rz(1.0, range(nqubits))
+    circuit.rx(1.0, range(nqubits))
+    circuit.rz(1.0, range(nqubits))
     return circuit
 
-def last_rotation(circuit, qubits):
-    for each in qubits:
-        circuit.rz(1.0, each)
-        circuit.rx(1.0, each)
+def last_rotation(circuit, nqubits):
+    circuit.rz(1.0, range(nqubits))
+    circuit.rx(1.0, range(nqubits))
     return circuit
 
-def entangler(circuit, qubits, pairs):
+def entangler(circuit, pairs):
     for a, b in pairs:
-        circuit.cx(qubits[a], qubits[b])
+        circuit.cx(a, b)
     return circuit
 
-def generate_qcbm_circuit(n, depth, pairs):
-    qubits = QuantumRegister(n)
-    circuit = QuantumCircuit(qubits)
-    
-    for each in qubits:
-        circuit.rx(1.0, each)
-        circuit.rz(1.0, each)
-
-    circuit = entangler(circuit, qubits, pairs)
+def generate_qcbm_circuit(nqubits, depth, pairs):
+    circuit = QuantumCircuit(nqubits)
+    first_rotation(circuit, nqubits)
+    entangler(circuit, pairs)
     for k in range(depth-1):
-        circuit = mid_rotation(circuit, qubits)
-        circuit = entangler(circuit, qubits, pairs)
-    circuit = last_rotation(circuit, qubits)
+        mid_rotation(circuit, nqubits)
+        entangler(circuit, pairs)
+    last_rotation(circuit, nqubits)
     return circuit
 
 
-nbit_list = range(4,26)
+nqubit_list = range(4, 26)
 
-@pytest.mark.parametrize('nqubits', nbit_list)
+@pytest.mark.parametrize('nqubits', nqubit_list)
 def test_X(benchmark, nqubits):
     benchmark.group = "X"
     run_bench(benchmark, nqubits, 'x')
 
-@pytest.mark.parametrize('nqubits', nbit_list)
+@pytest.mark.parametrize('nqubits', nqubit_list)
 def test_H(benchmark, nqubits):
     benchmark.group = "H"
     run_bench(benchmark, nqubits, 'h')
 
-@pytest.mark.parametrize('nqubits', nbit_list)
+@pytest.mark.parametrize('nqubits', nqubit_list)
 def test_T(benchmark, nqubits):
     benchmark.group = "T"
     run_bench(benchmark, nqubits, 't')
 
-@pytest.mark.parametrize('nqubits', nbit_list)
+@pytest.mark.parametrize('nqubits', nqubit_list)
 def test_CX(benchmark, nqubits):
     benchmark.group = "CNOT"
     run_bench(benchmark, nqubits, 'cx', (1, 2))
 
-@pytest.mark.parametrize('nqubits', nbit_list)
+@pytest.mark.parametrize('nqubits', nqubit_list)
 def test_Toffoli(benchmark, nqubits):
     benchmark.group = "Toffoli"
     run_bench(benchmark, nqubits, 'ccx', (2, 3, 0))
 
-# Rotation Z/X is not supported
-# @pytest.mark.parametrize('nqubits', nbit_list)
-# def test_qcbm(benchmark, nqubits):
-#     benchmark.group = "QCBM"
-#     circuit = generate_qcbm_circuit(nqubits, 9,
-#         [(i, (i+1)%nqubits) for i in range(nqubits)])
-#     native_execute(benchmark, circuit)
+@pytest.mark.parametrize('nqubits', nqubit_list)
+def test_qcbm(benchmark, nqubits):
+    benchmark.group = "QCBM"
+    pairs = [(i, (i + 1) % nqubits) for i in range(nqubits)]
+    circuit = generate_qcbm_circuit(nqubits, 9, pairs)
+    native_execute(benchmark, circuit, default_options)

--- a/qiskit/benchmarks.py
+++ b/qiskit/benchmarks.py
@@ -94,3 +94,16 @@ def test_qcbm(benchmark, nqubits):
     pairs = [(i, (i + 1) % nqubits) for i in range(nqubits)]
     circuit = generate_qcbm_circuit(nqubits, 9, pairs)
     native_execute(benchmark, circuit, default_options)
+
+# NOTE: The following benchmark requires installing Qiskit Aer with GPU
+# which is currently only available for Linux
+# install with: `pip install qiskit qiskit-aer-gpu`
+@pytest.mark.parametrize('nqubits', nqubit_list)
+def test_qcbm_cuda(benchmark, nqubits):
+    benchmark.group = "QCBM (cuda)"
+    pairs = [(i, (i + 1) % nqubits) for i in range(nqubits)]
+    circuit = generate_qcbm_circuit(nqubits, 9, pairs)
+    # Set simulation method to the GPU statevector
+    gpu_options = default_options.copy()
+    gpu_options["method"] = "statevector_gpu"
+    native_execute(benchmark, circuit, gpu_options)


### PR DESCRIPTION
Updates Qiskit benchmarks (Closes #9)

* Fixes incorrect backend usage: Benchmarks are now run on the "qasm_simulator" with options set to force used of the dense statevector simulation method with certain optimizations disabled (OpenMP and qubit truncation)

* Updates native_execute function for change of function name in Aer 0.4

* Includes QCBM circuit benchmarks for Qiskit.

* Adds CUDA GPU backend for QCBM circuit benchmarks (requires separate install of `qiskit-aer-gpu` which is currently only available on Linux).

@Roger-luo Let me know if you have any issues running the updated benchmarks (particularly the GPU benchmarks) on your test system.

![pcircuit_relative](https://user-images.githubusercontent.com/2235104/74170781-504ae880-4be2-11ea-93e4-daf821e9c871.png)

*Updated circuit benchmark for qiskit run on a server with a P100 GPU (Note I didn't re-run any of the other simulator benchmarks they are plotted from repo data)*