### PR TITLE
Updated files for JKQ-DDSIM

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -48,7 +48,7 @@ GPU: Tesla V100
 | Cirq                 | 0.7.0   | full amplitudes   |
 | PennyLane            | 0.8.1   | full amplitudes   |
 | QuEST (pyquest-cffi) | 0.1.1   | full amplitudes   |
-| JKQ DDSIM¹           | v1.0.1a | decision diagrams |
+| JKQ DDSIM¹           | v1.1    | decision diagrams |
 
 ¹ This benchmark uses the mean estimator for the timings. To get accurate timings when recreating the results, please ensure no other other applications run concurrently.
 

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -13,7 +13,7 @@ function run_benchmark {
     export JULIA_NUM_THREADS=1
 
     printf "${BLUE}benchmarking:${NC} ${BOLD}$1${NC}\n"
-    (cd $1 && sh benchmarks.sh)
+    (cd $1 && bash benchmarks.sh)
 }
 
 function setup {

--- a/jkq-ddsim/benchmarks.sh
+++ b/jkq-ddsim/benchmarks.sh
@@ -1,19 +1,14 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# FILE_PATH=$(readlink -f "$0")
-# BASE_PATH=$(dirname "$FILE_PATH")
+FILE_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+ROOT_PATH=$(dirname "$FILE_PATH")
+. "$ROOT_PATH/bin/utils/constants.sh"
 
-# BENCHMARK_DATA_PATH="$1"
+# env vars do not work https://github.com/google/benchmark/issues/913
+#export BENCHMARK_OUT_FORMAT='csv'
+#export BENCHMARK_OUT="$BENCHMARK_DATA_PATH/jku-ddsim.csv"
 
-# cd "$BASE_PATH"
+# to restrict the benchmarks to the single gate ones, use --benchmark_filter=BM_sim_[XHTC]
+mkdir -p "$BENCHMARK_DATA_PATH"
+build/apps/ddsim_benchmark --benchmark_filter=BM_sim_ --benchmark_out_format=json --benchmark_out="$BENCHMARK_DATA_PATH/jkq-ddsim.json" 
 
-# # env vars do not work https://github.com/google/benchmark/issues/913
-# #export BENCHMARK_OUT_FORMAT='csv'
-# #export BENCHMARK_OUT="$BENCHMARK_DATA_PATH/jku-ddsim.csv"
-
-# # to restrict the benchmarks to the single gate ones, use --benchmark_filter=BM_sim_[XHTC]
-# build/apps/ddsim_benchmark --benchmark_filter=BM_sim_ --benchmark_out_format=json --benchmark_out="$BENCHMARK_DATA_PATH/jkq-ddsim.json" 
-
-echo "benchmarking jkq-ddsim..."
-sleep 5
-echo "finished $(basename $(dirname $0))"

--- a/jkq-ddsim/setup.sh
+++ b/jkq-ddsim/setup.sh
@@ -8,10 +8,11 @@ BINDIR="$ROOT_PATH/bin"
 cd "$FILE_PATH"
 
 if [ ! -d "ddsim" ]; then
-    git clone --branch "v1.0.1a" --depth 1  https://github.com/iic-jku/ddsim ddsim
+    git clone --branch "v1.1" --depth 1  https://github.com/iic-jku/ddsim ddsim
     git -C ddsim submodule update --init --recursive
 fi
 
-cmake -DGIT_SUBMODULE=OFF -DBENCHMARK_ENABLE_LTO=true -DCMAKE_BUILD_TYPE=Release -S ddsim -B ddsim
+# these options require cmake >= 3.13
+cmake -DGIT_SUBMODULE=OFF -DBENCHMARK_ENABLE_LTO=true -DCMAKE_BUILD_TYPE=Release -S ddsim -B build 
 cmake --build build --config Release --target ddsim_benchmark
 


### PR DESCRIPTION
This PR fixes #17 by making the Boost depdency optional (and only required to build the simulator standalone executable). Building the benchmark executable now works without Boost.

@Roger-luo Could you please rerun the evaluation?
